### PR TITLE
fix(ci): `cache-dependency-glob`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv pip install jax flax fire ruff pytest
+        run: uv pip install jax flax fire ruff pytest --system
 
       - name: Ruff
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip
-          pip install jax flax fire
+          pip install jax flax fire pytest
           pip install git+https://github.com/black-forest-labs/flux.git
       - name: Test with PyTest
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,8 +39,12 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip
-          pip install jax flax fire pytest
+          pip install jax flax fire pytest ruff
           pip install git+https://github.com/black-forest-labs/flux.git
+
+      - name: ruff
+        run: ruff check jflux
+      
       - name: Test with PyTest
         run: |
           pytest -v -s .

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-extras --dev
+        run: uv pip install jax flax fire ruff pytest
 
       - name: Ruff
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,6 +15,7 @@ on:
     types: [created]
   schedule:
     - cron: "0 0 * * 0"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,21 +29,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
 
       - name: Install dependencies
-        run: uv pip install jax flax fire ruff pytest --system
+        run: pip install -U pip && pip install -e .
 
-      - name: Ruff
-        run: |
-          uv run ruff check jflux
       - name: Test with PyTest
         run: |
-          uv run pytest -v -s .
+          pytest -v -s .

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,13 +5,11 @@ on:
     branches: [main]
     paths:
       - "**.py"
-      - ".devcontainer/requirements.txt"
       - ".github/workflows/python.yml"
   pull_request:
     branches: [main]
     paths:
       - "**.py"
-      - ".devcontainer/requirements.txt"
       - ".github/workflows/python.yml"
   release:
     types: [created]
@@ -24,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest]
 
     steps:
@@ -34,7 +32,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          cache-dependency-glob: "pyproject.toml"
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -47,4 +45,4 @@ jobs:
           uv run ruff check jflux
       - name: Test with PyTest
         run: |
-          uv run pytest -v .
+          uv run pytest -v -s .

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,8 +37,10 @@ jobs:
           cache-dependency-path: "pyproject.toml"
 
       - name: Install dependencies
-        run: pip install -U pip && pip install -e .
-
+        run: |
+          pip install -U pip
+          pip install jax flax fire
+          pip install git+https://github.com/black-forest-labs/flux.git
       - name: Test with PyTest
         run: |
           pytest -v -s .

--- a/jflux/cli.py
+++ b/jflux/cli.py
@@ -4,19 +4,19 @@ import time
 from dataclasses import dataclass
 from glob import iglob
 
-import torch
 import jax
 import jax.numpy as jnp
 import numpy as np
+import torch
 from einops import rearrange
 from fire import Fire
 from flax import nnx
 from PIL import Image
 
 from jflux.sampling import denoise, get_noise, get_schedule, prepare, unpack
-from jflux.util import configs, load_ae, load_clip, load_flow_model, load_t5, torch2jax
+from jflux.util import configs, load_ae, load_clip, load_flow_model, load_t5
 
-import os
+
 os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
 
 @dataclass

--- a/jflux/modules/layers.py
+++ b/jflux/modules/layers.py
@@ -1,7 +1,6 @@
 import math
 from dataclasses import dataclass
 
-import jax
 import jax.numpy as jnp
 from chex import Array
 from einops import rearrange


### PR DESCRIPTION
* drops redundant paths from GA workflow
* fixes `cache-dependency-glob`
* enables capturing std-out on CI 
* test on `3.10` and above