### PR TITLE
running on tpu

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -36,10 +36,20 @@ To get started, follow these simple steps:
 > uv python pin 3.10
 > ```
 >
-> If you don't have `uv` you can run the following command to get running
+> If you don't have `uv` you can run the following command to get running. 
+
+For GPU:
+
 > ```
-> cd jflux && pip install -U pip && pip install -e .
+> cd jflux && pip install -U pip && pip install -e .[gpu]
 > ```
+
+For TPU:
+
+> ```
+> cd jflux && pip install -U pip && pip install -e .[tpu]
+> ```
+
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,19 @@ license = { file = "LICENSE.md" }
 dependencies = [
     "fire>=0.7.0",
     "flax>=0.9.0",
-    "jax[cuda]>=0.4.34",
+]
+
+[project.optional-dependencies]
+gpu = [
+  "jax[cuda]>=0.4.34",
+]
+tpu = [
+  "libtpu-nightly @ https://storage.googleapis.com/libtpu-nightly-releases/wheels/libtpu-nightly/libtpu_nightly-0.1.dev20241017+nightly-py3-none-any.whl",
+  "torch",
+  "torchvision",
+  "sentencepiece",
+  "transformers",
+  "einops"
 ]
 
 [project.scripts]


### PR DESCRIPTION
This PR adds the ability to run on TPUs, although its very slow right now. I'm unsure how to this hooks into `uv` as I used pip. Please review.

* Loads encoders on CPU when device_type == 'tpu'.
* Can run on 32GB of HBM, i.e., TPUv4. 