### PR TITLE
chore(deps): add chex as a CI dependency

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pip
-          pip install jax flax fire pytest ruff
+          pip install chex jax flax fire pytest ruff
           pip install git+https://github.com/black-forest-labs/flux.git
 
       - name: ruff


### PR DESCRIPTION
explicitly add `chex` as a dependency. Fixes [errors](https://github.com/ml-gde/jflux/actions/runs/21791432977) in CI